### PR TITLE
update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Update `package.json` (**The order of the scripts is important!**):
 ```json
 {
   "scripts": {
-    "lint": "run-s --continue-on-error lint:*",
+    "lint": "astro sync && run-s --continue-on-error lint:*",
+    "lint:eslint": "eslint . --cache --fix --report-unused-disable-directives",
     "lint:types": "tsc -b",
     "lint:astro": "astro check",
-    "lint:eslint": "eslint . --cache --fix --report-unused-disable-directives",
     "lint:prettier": "prettier . \"**/*.astro\" --cache --write --list-different"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,10 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "lint": "run-s --continue-on-error lint:*",
-    "lint:astro": "astro check",
-    "lint:types": "tsc -b",
-    "lint:types-workspaces": "pnpm -r exec tsc -b",
+    "lint": "astro sync && run-s --continue-on-error lint:*",
     "lint:eslint": "eslint . --cache --fix --report-unused-disable-directives",
+    "lint:types": "tsc -b",
+    "lint:astro": "astro check",
     "lint:prettier": "prettier . \"**/*.astro\" --cache --write --list-different",
     "test": "playwright test",
     "test:e2e": "run-s test:build test:preview",


### PR DESCRIPTION
sync should run first, then eslint, so that eslint fixes any issues that would've been type errors (like `import type` related things)