### PR TITLE
modify @typescript-eslint/prefer-nullish-coalescing

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -72,6 +72,9 @@ module.exports = {
 		'@typescript-eslint/no-unsafe-argument': 'warn',
 		'@typescript-eslint/no-unsafe-assignment': 'warn',
 		'@typescript-eslint/no-import-type-side-effects': 'error',
-	"@typescript-eslint/prefer-nullish-coalescing": [ "warn", { "ignorePrimitives": { "string": true, "boolean": true } } ]
+		'@typescript-eslint/prefer-nullish-coalescing': [
+			'warn',
+			{ ignorePrimitives: { string: true, boolean: true } },
+		],
 	},
 };

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -72,5 +72,6 @@ module.exports = {
 		'@typescript-eslint/no-unsafe-argument': 'warn',
 		'@typescript-eslint/no-unsafe-assignment': 'warn',
 		'@typescript-eslint/no-import-type-side-effects': 'error',
+	"@typescript-eslint/prefer-nullish-coalescing": [ "warn", { "ignorePrimitives": { "string": true, "boolean": true } } ]
 	},
 };


### PR DESCRIPTION
change it to a warning, and allow using `||` to coalesce empty string and false